### PR TITLE
Support sending and receiving "infinitely".

### DIFF
--- a/monitor/server/prometheus.yml
+++ b/monitor/server/prometheus.yml
@@ -16,4 +16,4 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['ec2-54-89-243-31.compute-1.amazonaws.com:9103']
+      - targets: ['localhost:7777']

--- a/nats-client-sim/configs/pub1_sub1_infinte.json
+++ b/nats-client-sim/configs/pub1_sub1_infinte.json
@@ -1,0 +1,36 @@
+{
+  "client_start_delay_max": 0,
+  "tlsca": "",
+  "tlscert": "",
+  "tlskey": "",
+  "usetls": true,
+  "clients": [
+    {
+      "name": "pub-0",
+      "instances": 1,
+      "username": "colin",
+      "password": "password",
+      "pub_msgsize": 512,
+      "pub_delay": "20us",
+      "pub_msgcount": -1,
+      "pub_subject": "foo",
+      "subscriptions": null
+    },
+    {
+      "name": "sub-0",
+      "instances": 1,
+      "username": "colin",
+      "password": "password",
+      "pub_msgsize": 0,
+      "pub_delay": "",
+      "pub_msgcount": 0,
+      "pub_subject": "",
+      "subscriptions": [
+        {
+          "count": -1,
+          "subject": "foo"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Use int64 for message counts (rollover not tested)
* -1 in configuration for pub and sub msg counts means "infinite"
* Also revert the prometheus config file to it's original contents